### PR TITLE
reverted changes

### DIFF
--- a/server/routes/OrderClient.ts
+++ b/server/routes/OrderClient.ts
@@ -39,7 +39,7 @@ import * as request from 'request-promise-native';
         });
     }
 
-    public saveOrder(order: string): Promise<string> {
+    public saveOrder(order: orderDomain.Order): Promise<orderDomain.Order> {
         return request.post(
             this.config.getOrderMSURL(),
             {json: true,
@@ -49,11 +49,11 @@ import * as request from 'request-promise-native';
              body: order 
             })
             .then(body => {
-                return <string>body;
+                return <orderDomain.Order>body;
             })
             .catch(err => {
                 console.error(err);
-                order = "Error " + err;
+                order.status = "Error " + err;
                 return new Promise((resolve, _) => {
                     resolve(order);
                 });


### PR DESCRIPTION
I reverted the changes to fix  this issue:
routes/api.ts(141,50): error TS2345: Argument of type '(data: Order) => void' is not assignable to parameter of type '(value: string) => void | PromiseLike<void>'.
  Types of parameters 'data' and 'value' are incompatible.
    Type 'string' is not assignable to type 'Order'.
