### PR TITLE
Update hostname for order-command-ms

### DIFF
--- a/chart/kc-ui/values.yaml
+++ b/chart/kc-ui/values.yaml
@@ -54,7 +54,7 @@ serviceAccountName: default
 application:
   fleetServiceHost: fleetms-service
   fleetServicePort: 9080
-  orderCommandServiceHost: ordercommandms-service
+  orderCommandServiceHost: order-command-ms
   orderCommandServicePort: 9080
   orderQueryServiceHost: orderqueryms-service
   orderQueryServicePort: 9080


### PR DESCRIPTION
Update the Helm deployment so that hostname matches the service created by Appsody. This goes with https://github.com/ibm-cloud-architecture/refarch-kc-order-ms/pull/72 and should probably be merged at the same time.