### PR TITLE
Change host name for order-query

### DIFF
--- a/chart/kc-ui/values.yaml
+++ b/chart/kc-ui/values.yaml
@@ -56,7 +56,7 @@ application:
   fleetServicePort: 9080
   orderCommandServiceHost: order-command-ms
   orderCommandServicePort: 9080
-  orderQueryServiceHost: orderqueryms-service
+  orderQueryServiceHost: order-query-ms
   orderQueryServicePort: 9080
   voyageServiceHost: voyagesms-service
   voyageServicePort: 3000


### PR DESCRIPTION
Update the hostname for order-query-ms to the name of the service that's generated by Appsody. 