### PR TITLE
Update container and voyages service names

### DIFF
--- a/chart/kc-ui/values.yaml
+++ b/chart/kc-ui/values.yaml
@@ -58,7 +58,7 @@ application:
   orderCommandServicePort: 9080
   orderQueryServiceHost: order-query-ms
   orderQueryServicePort: 9080
-  voyageServiceHost: voyagesms-service
+  voyageServiceHost: voyages-ms
   voyageServicePort: 3000
-  containerServiceHost: springcontainerms-service
+  containerServiceHost: spring-container-ms
   containerServicePort: 8080


### PR DESCRIPTION
Update the helm chart to default the service names for the container and voyage microservices to match the values generated by Appsody (see ibm-cloud-architecture/refarch-kc-container-ms#50 and ibm-cloud-architecture/refarch-kc-ms#51 respectively).