### PR TITLE
Update Helm chart with Appsody naming and part-of labels

### DIFF
--- a/chart/kc-ui/templates/deployment.yaml
+++ b/chart/kc-ui/templates/deployment.yaml
@@ -1,9 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{  .Chart.Name }}-deployment"
+  name: "kc-ui"
   labels:
     chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/chart/kc-ui/templates/ingress.yaml
+++ b/chart/kc-ui/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: "{{ $chartName }}-service"
+              serviceName: "kc-ui"
               servicePort: http
   {{- end }}
 {{- end }}

--- a/chart/kc-ui/templates/route.yaml
+++ b/chart/kc-ui/templates/route.yaml
@@ -8,11 +8,12 @@ metadata:
   name: {{ .Values.route.urlPrefix }}
   labels:
     chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   path: {{ $routePath }}
   to:
     kind: Service
-    name: "{{ $chartName }}-service"
+    name: "kc-ui"
     weight: 100
   port:
     targetPort: http

--- a/chart/kc-ui/templates/service.yaml
+++ b/chart/kc-ui/templates/service.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{  .Chart.Name }}-service"
+  name: "kc-ui"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/chart/kc-ui/values.yaml
+++ b/chart/kc-ui/values.yaml
@@ -52,7 +52,7 @@ eventstreams:
   caPemSecretName: es-ca-pemfile
 serviceAccountName: default
 application:
-  fleetServiceHost: fleetms-service
+  fleetServiceHost: fleet-ms
   fleetServicePort: 9080
   orderCommandServiceHost: order-command-ms
   orderCommandServicePort: 9080


### PR DESCRIPTION
This renames the Helm deployment names to match those that Appsody will generate, and updates references to the deployment / service names. Rather than updating the istio resource, I chose to remove it altogether, as it is written against an obsolete version of the API.

I've added the part-of label to the deployment, service and route resources so that we can select groups of those resources based on labels. This is also then consistent with the Appsody operator, which will automatically apply that label to the resources it creates.

I also updated the name of the fleet-ms service name to be consistent with https://github.com/ibm-cloud-architecture/refarch-kc-ms/pull/52.

Although this microservice is not yet packaged as an Appsody application, updating the naming now enables us to be consistent in naming (for example, it enables https://github.com/ibm-cloud-architecture/refarch-kc/pull/105), and means that other references will not need to be updated once it has been repackaged.