### PR TITLE
Specify PORT to match appsody service port

### DIFF
--- a/app-deploy.yaml
+++ b/app-deploy.yaml
@@ -37,6 +37,8 @@ spec:
   applicationImage: ibmcase/kcontainer-ui:latest
   createKnativeService: false
   env:
+  - name: PORT
+    value: "3000"
   - name: FLEETMS_SERVICE_HOST
     value: fleet-ms
   - name: FLEETMS_SERVICE_PORT


### PR DESCRIPTION
Unfortunately I found a bug when deploying this service using Appsody:  the default port used by the app (3010) doesn't match the port defined by the AppsodyApplication (3000), and so the service and route are nonfunctional.

I fixed the consumption of the `PORT` env var (uppercase) in #82, but forgot to actually specify `PORT` in the env vars for the included `app-deploy.yaml`.  This PR adds that in.