### PR TITLE
SCRAM credentials for ES v10

### DIFF
--- a/chart/kc-ui/templates/deployment.yaml
+++ b/chart/kc-ui/templates/deployment.yaml
@@ -79,11 +79,16 @@ spec:
                 name: "{{ .Values.kafka.topicsConfigMap }}"
                 key: bluewaterShipTopic
           {{- if .Values.eventstreams.enabled }}
-          - name: KAFKA_APIKEY
+          - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.eventstreams.apikeyConfigMap }}"
-                key: binding
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: username
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: password
           {{- if .Values.eventstreams.caPemFileRequired }}
           - name: CERTS_ENABLED
             value : "true"

--- a/chart/kc-ui/values.yaml
+++ b/chart/kc-ui/values.yaml
@@ -45,11 +45,11 @@ kafka:
   topicsConfigMap: kafka-topics
 eventstreams:
   enabled: true
-  apikeyConfigMap: eventstreams-apikey
+  esCredSecret: eventstreams-cred
   caPemFileRequired: false
   caPemFilePath: "/etc/ssl/certs/kcontainer"
   caPemFileName: "es-cert.pem"
-  caPemSecretName: es-ca-pemfile
+  caPemSecretName: eventstreams-cert-pem
 serviceAccountName: default
 application:
   fleetServiceHost: fleet-ms

--- a/server/config/AppConfig.ts
+++ b/server/config/AppConfig.ts
@@ -12,8 +12,12 @@ export default class AppConfig {
         return process.env.KAFKA_BROKERS || config.kafkaBrokers;
     }
 
-    public getKafkaApiKey(): string {
-        return process.env.KAFKA_APIKEY ||  config.kafkaApiKey;
+    public getKafkaPassword(): string {
+        return process.env.KAFKA_PASSWORD ||  config.kafkaPassword;
+    }
+
+    public getKafkaUser(): string {
+        return process.env.KAFKA_USER ||  config.kafkaUser;
     }
 
     public getFleetMSURL(): string {
@@ -90,7 +94,7 @@ export default class AppConfig {
     }
 
     public isEventStreams(): boolean {
-        return ('KAFKA_APIKEY' in process.env && process.env.KAFKA_APIKEY.trim() !=="");
+        return ('KAFKA_PASSWORD' in process.env && process.env.KAFKA_PASSWORD.trim() !=="");
     }
 
     public eventStreamsSecurityEnabled(): boolean {

--- a/server/routes/kafka.js
+++ b/server/routes/kafka.js
@@ -9,11 +9,20 @@ var fs = require('fs');
 
 const getCloudConfig = () => {
   var _config = {
-      'security.protocol': 'sasl_ssl',
-      'sasl.mechanisms': 'PLAIN',
-      'sasl.username': 'token',
-      'sasl.password': config.getKafkaApiKey()
+    'security.protocol': 'sasl_ssl',
+    'sasl.username': config.getKafkaUser(),
+    'sasl.password': config.getKafkaPassword()
   };
+
+  // If we are connecting to ES on IBM Cloud, the SASL mechanism is plain
+  if(_config['sasl.username'] === 'token'){
+    _config['sasl.mechanisms'] = 'PLAIN'
+  }
+  // If we are connecting to ES on OCP, the SASL mechanism is scram-sha-512
+  else {
+    _config['sasl.mechanisms'] = 'SCRAM-SHA-512'
+  }
+  
   if(config.eventStreamsSecurityEnabled()){
     _config['ssl.ca.location'] = config.getCertsPath();
   }


### PR DESCRIPTION
Refactoring to allow new authentication mechanism in ES v10 that uses SCRAM. There is also some refactoring on the names for the secrets/configmaps that this microservices will be loading config from.

This is one of the changes suggested in ibm-cloud-architecture/refarch-kc#119